### PR TITLE
Add update functionality to comment

### DIFF
--- a/.github/workflows/pr-reviewer.yaml
+++ b/.github/workflows/pr-reviewer.yaml
@@ -86,12 +86,45 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
 
-      - uses: actions/github-script@v6
+      - name: Get github-actions bot comment id (if exists)
+        id: get_comment_id
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          comments_json=$(curl -s -L -X GET \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments)
+          comment_id=$(echo "$comments_json" | jq -r '[.[] | select(.user.login=="github-actions[bot]") | .id][0] // ""')
+          echo "comment_id=$comment_id" >> $GITHUB_ENV
+          echo "Resolved comment id: ${comment_id:-<none>}"
+
+      - name: Create or update PR review comment
+        uses: actions/github-script@v6
+        env:
+          COMMENT_ID: ${{ env.comment_id }}
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: process.env.response
-            })
+            const body = process.env.response || '(no response content)';
+            const existing = process.env.COMMENT_ID;
+            if (!existing) {
+              core.info('No existing github-actions[bot] comment. Creating a new one.');
+              const { data } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+              core.info(`Created comment id ${data.id}`);
+            } else {
+              core.info(`Updating existing comment id ${existing}`);
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: Number(existing),
+                body
+              });
+              core.info('Update complete');
+            }

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   terraform:
@@ -24,10 +23,7 @@ jobs:
       - name: Az CLI login
         uses: azure/login@v1
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          allow-no-subscriptions: true
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Terraform Init
         working-directory: components

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -27,6 +27,7 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          allow-no-subscriptions: true
 
       - name: Terraform Init
         working-directory: components

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   terraform:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -25,6 +25,10 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.13.3"
+
       - name: Terraform Init
         working-directory: components
         env:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -23,7 +23,9 @@ jobs:
       - name: Az CLI login
         uses: azure/login@v1
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform Init
         working-directory: components


### PR DESCRIPTION
### Change description

Enable functionality for existing comments to be updated rather than creating multiple comments.
Will only work if the bot comments once per run.

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change












## 🤖AEP PR SUMMARY🤖


### .github/workflows/pr-reviewer.yaml
- Added a new step to get the github-actions bot comment ID, if it exists, using a GitHub API call.
- Updated the Create or update PR review comment step to conditionally create or update a PR review comment based on the existence of an existing comment ID.

### .github/workflows/terraform.yaml
- Added the `hashicorp/setup-terraform@v3` action to set up Terraform with version \"1.13.3\" for the `Terraform Init` job.